### PR TITLE
export HDF file

### DIFF
--- a/python/ifigure/utils/hdf_data_export.py
+++ b/python/ifigure/utils/hdf_data_export.py
@@ -1,0 +1,158 @@
+'''
+
+   Export (partial) Figure Data to HDF file
+
+
+
+'''
+import traceback
+import six
+from collections import OrderedDict
+
+from ifigure.widgets.artist_widgets import listparam, call_getter 
+
+def get_all_properties(obj, use_str = True):
+    ret =  obj.property_for_shell()
+    tags = None
+    if isinstance(ret, tuple):
+       tab = ret[0]
+       props = ret[1]
+       if len(ret) == 3:
+           tags = ret[2]
+    else:
+       tab = ['']
+       props = [ret]
+    if tags is None: tags =['']*len(props)
+
+    ll = []
+    for tag, plist in zip(tags, props):
+        for p in plist:
+            if tag == '':
+                ll.append(('',  listparam[p][6], listparam[p]))
+            else:
+                ll.append((tag, listparam[p][6], listparam[p]))
+
+    props =  {}            
+    for lll in ll:                
+        tag, name, lp = lll
+        ret = [call_getter(a, lp, tab = tag) for a in obj._artists]
+        if use_str: ret = ret.__repr__()
+        if tag == '': 
+           props[name] = ret
+        else:
+           props['_'.join((tag, name))] = ret
+    return props
+        
+def build_data(page, verbose=True):
+    book = page.get_figbook()    
+    dataset = OrderedDict()
+    for obj in page.walk_tree():
+        if obj is page:
+            name = page.name
+        else:
+            name = page.name + '.' + '.'.join(page.get_td_path(obj)[1:])
+        dataset[name] = {}
+        try:
+            dd = obj.export()
+        except NotImplementedError:
+            if verbose:            
+                print(name + ' does not have data to export')
+        except:
+            print('Unexpected error')
+            raise
+        else:
+            for kk,  ddd in enumerate(dd):
+               dataset[name]['data'+str(kk+1)] = ddd
+            if verbose:
+                txt = ['member '+ str(i) + ' exprot ' + ','.join(d.keys()) for i, d in enumerate(dd)]
+                print(name + ' : ' + ','.join(txt))
+        try:
+            props = get_all_properties(obj, use_str = True)
+        except:
+            print('Unexpected error')
+            raise
+        else:
+            dataset[name]['property'] = props
+            if verbose:
+                txt = '\n'.join([k + ':' + props[k] for k in props])
+                print('property')
+                print(txt)                
+                
+    return dataset
+    
+def hdf_data_export(page = None,
+                    filename = 'data.hdf',
+                    verbose = True,
+                    dry_run = False,
+                    data = None,
+                    export_flag = None):
+    if data is None:
+        if page is None:
+            print('Error: Specify either page object or data')
+            return
+        data = build_data(page, verbose = verbose)
+    if dry_run: return
+    if export_flag is None: export_flag = {}
+    
+    from netCDF4 import Dataset
+    rootgrp = Dataset(filename, "w", format="NETCDF4")
+    
+    import time
+    
+    rootgrp.description = "Figure data exported from piScope"
+    rootgrp.history = "Created " + time.ctime(time.time())    
+
+    for key in six.iterkeys(data):
+        key_grp = rootgrp.createGroup(key)
+        
+        props = data[key]['property']
+        for key2 in six.iterkeys(props):
+            labels = (key, 'property', key2)
+            #print 'checking ', labels            
+            if (labels in export_flag and
+                not export_flag[labels]): continue
+            setattr(key_grp, key2, props[key2])
+
+            
+        data_keys = [k for k in  data[key].keys() if k.startswith('data')]
+        for i, k in enumerate(data_keys):
+            ddd = data[key][k]
+            for key2 in six.iterkeys(ddd):
+                labels = (key, k, key2)
+                #print 'checking ', labels
+                if (labels in export_flag and
+                     not export_flag[labels]): continue
+                
+                dimnames = []
+                dataname = '_'.join(('data', str(i), key2))
+                for j, s in enumerate(ddd[key2].shape):
+                   dimname = dataname + '_s_' + str(j+1)
+                   dim= key_grp.createDimension(dimname, s)
+                   dimnames.append(dimname)
+
+                do_complex = False
+                if ddd[key2].dtype == float:
+                    stype = 'f8'
+                elif ddd[key2].dtype == int:
+                    stype = 'i8'               
+                elif ddd[key2].dtype == complex:                        
+                    stype = 'f8'
+                    do_complex = True
+                else:
+                    continue
+                if do_complex:
+                    var = key_grp.createVariable('Re_'+key2 ,stype,
+                                                 tuple(dimnames))
+                    var[:] = ddd[key2].real                        
+                    var = key_grp.createVariable('Im_'+key2 ,stype,
+                                                 tuple(dimnames))
+                    var[:] = ddd[key2].imag                        
+                else:
+                    var = key_grp.createVariable(key2 ,stype, tuple(dimnames))
+                    var[:] = ddd[key2]
+                        
+                    
+    rootgrp.close()        
+
+    return data
+    

--- a/python/ifigure/widgets/book_viewer.py
+++ b/python/ifigure/widgets/book_viewer.py
@@ -599,10 +599,14 @@ class BookViewerFrame(FramePlus, BookViewerInteractive):
         #                        "3D buttons", "", 
         #                        self.onToggle3DMenu, kind = wx.ITEM_CHECK)
 
-    def add_saveimage_menu(self, filemenu):
-        self.add_menu(filemenu, BookViewerFrame.ID_SAVEIMAGE, 
+    def add_saveimage_menu(self, parent):
+        self.add_menu(parent, BookViewerFrame.ID_SAVEIMAGE, 
                      "Save Image", "Save Image", 
                       self.onSaveImage)
+    def add_exporthdf_menu(self, parent):
+        self.add_menu(parent, wx.ID_ANY, 
+                     "HDF data...", "Export HDF data.", 
+                      self.onExportHDF)
 
     def append_screen_ratio_menu(self, viewmenu):
         ratiomenu = wx.Menu()
@@ -896,7 +900,12 @@ class BookViewerFrame(FramePlus, BookViewerInteractive):
 
     def onSaveImage(self, evt):
         self.canvas.save_pic()
-
+        evt.Skip()
+        
+    def onExportHDF(self, evt):
+        self.canvas.export_hdf()
+        evt.Skip()
+        
     def onNewBook(self, evt, viewer=None, proj=None, basename=None, **kwargs):
         if viewer is None: 
            dprint1('onNewBook is called with viewer = None')
@@ -1700,13 +1709,17 @@ class BookViewer(BookViewerFrame):
                      self.onLoadBookNew)
         self.filemenu.AppendSeparator()
         self.append_save_project_menu(self.filemenu)
-        self.export_book_menu = self.add_menu(self.filemenu, BookViewerFrame.ID_EXPORTBOOK, 
-                     "Export Book", "Export Book", 
-                     self.onExportBook)
-        self.add_menu(self.filemenu, BookViewerFrame.ID_EXPORTBOOK_AS,
+        exportmenu = wx.Menu()
+        self.filemenu.AppendMenu(wx.ID_ANY, 'Export...', exportmenu)
+        self.export_book_menu = self.add_menu(exportmenu,
+                                        BookViewerFrame.ID_EXPORTBOOK, 
+                                        "Export Book", "Export Book",
+                                        self.onExportBook)
+        self.add_menu(exportmenu, BookViewerFrame.ID_EXPORTBOOK_AS,
                      "Export Book As...", "Export Book", 
                      self.onExportBookAs)
-        self.add_saveimage_menu(self.filemenu)
+        self.add_saveimage_menu(exportmenu)
+        self.add_exporthdf_menu(exportmenu)        
         self.filemenu.AppendSeparator()
         self.add_menu(self.filemenu, wx.ID_ANY,
                       "Preference...","Piescope preference...", 

--- a/python/ifigure/widgets/canvas/ifigure_canvas.py
+++ b/python/ifigure/widgets/canvas/ifigure_canvas.py
@@ -3157,7 +3157,17 @@ class ifigure_canvas(wx.Panel, RangeRequestMaker):
        matplotlib.rcParams['text.usetex'] = org_rc[0]
        matplotlib.rcParams['ps.usedistiller'] = org_rc[1]
        matplotlib.rcParams['font.family'] = org_rc[2]
+       
+   def export_hdf(self):
 
+       from ifigure.widgets.hdf_export_window import HdfExportWindow
+
+
+       window = self.GetTopLevelParent()       
+       page = self._figure.figobj
+       w = HdfExportWindow(parent = window,
+                          page = page)
+       
    def _clean_selection(self):
       for item in self.selection:
           if item() is None: 

--- a/python/ifigure/widgets/hdf_export_window.py
+++ b/python/ifigure/widgets/hdf_export_window.py
@@ -1,0 +1,191 @@
+import os
+import traceback
+import wx
+import wx.dataview as dv
+import six
+from ifigure.utils.hdf_data_export import build_data,  hdf_data_export
+
+'''
+   HDFExportWindow(page = 
+
+
+'''
+class HDFDataModel(dv.PyDataViewModel):
+    def __init__(self, **kwargs):
+        dv.PyDataViewModel.__init__(self)
+        self.dataset = kwargs.pop('dataset', None)
+        self.export_flag = kwargs.pop('export_flag')
+        #self.objmapper.UseWeakRefs(True)
+        
+    def GetChildren(self, parent, children):
+        if not parent:
+            num = 0            
+            for name in six.iterkeys(self.dataset):
+                obj =(name,)
+                children.append(self.ObjectToItem(obj))
+                self.export_flag[obj] = True
+                num = num + 1
+            return num
+        
+        labels = self.ItemToObject(parent)
+        p = self.dataset[labels[0]]
+        for l in labels[1:]:
+            p = p[l]
+        if isinstance(p, dict):
+            num = 0
+            for newlabel in sorted(p.keys()):
+                print newlabel
+                x = list(labels)
+                x.append(newlabel)
+                obj = tuple(x)
+                children.append(self.ObjectToItem(obj))
+                self.export_flag[obj] = True                
+                num = num + 1
+            return num
+        return 0
+    
+    def GetParent(self, item):
+        if not item:
+            return dv.NullDataViewItem
+
+        labels = self.ItemToObject(item)
+        if len(labels) == 1:
+            return dv.NullDataViewItem
+        else:
+            return self.ObjectToItem(labels[:-1])
+    def GetColumnCount(self):
+        print 'GetColumnCount'
+        return 4
+    def GetColumnType(self, col):
+        print 'GetColumnType'        
+        mapper = { 0 : 'string',
+                   1 : 'bool',                   
+                   2 : 'string',
+                   3 : 'string',}
+        return mapper[col]
+    def IsContainer(self, item):
+        # The hidden root is a container
+        if not item:
+            return True
+        # and if it is dict, the objects are containers
+        labels = self.ItemToObject(item)
+        p = self.dataset
+        for l in labels:
+            p = p[l]
+        if isinstance(p, dict): return True        
+        # but everything else are not
+        return False            
+
+    def GetValue(self, item, col):
+        labels = self.ItemToObject(item)
+        p = self.dataset
+        for l in labels:
+            p = p[l]
+            
+        if col == 0:
+            v = labels[-1]
+            ret = v
+        elif col == 1:
+            ret = self.export_flag[labels]
+        elif col == 2:
+            ret = str(p)
+        elif col == 3:
+            if hasattr(p, 'shape'):
+                ret = str(p.shape)
+            else:
+                ret = ''
+        else:
+            pass
+        return ret
+    def SetValue(self, value, item, col):
+
+        labels = self.ItemToObject(item)
+        print value, labels
+        p = self.dataset        
+        for l in labels:
+            p = p[l]
+        if col == 1:
+            self.export_flag[labels] = value
+
+class HdfExportWindow(wx.Frame):
+    def __init__(self, *args, **kargs):
+        page = kargs.pop('page', None)
+        if page is None:  return
+        parent = kargs.pop('parent', None)
+        title  = kargs.pop('title', 'HDF export')
+        path = kargs.pop('path', os.path.join(os.getcwd(), 'data.hdf'))
+
+        self.dataset = build_data(page, verbose = False)
+
+        style = (wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|
+                 wx.RESIZE_BORDER)
+        if parent is not None:
+            style = style | wx.FRAME_FLOAT_ON_PARENT
+                                
+        wx.Frame.__init__(self, *args,
+                          style = style, 
+                          title = title, parent = parent)
+        self.SetSizer(wx.BoxSizer(wx.VERTICAL))
+        sizer = self.GetSizer()
+        sizer_h =wx.BoxSizer(wx.HORIZONTAL)
+
+        wildcard = "HDF(hdf)|*.hdf|Any|*.*"
+        self.filepicker = wx.FilePickerCtrl(self,
+                                            style=wx.FLP_SAVE|wx.FLP_USE_TEXTCTRL,
+                                            path = path,
+                                            wildcard = wildcard)
+        self.dataviewCtrl = dv.DataViewCtrl(self,
+                                            style = (dv.DV_VERT_RULES|
+                                                     dv.DV_MULTIPLE))
+        self.dataviewCtrl.AppendTextColumn('name', 0,
+                                           width = 150)
+        self.dataviewCtrl.AppendToggleColumn('export', 1,
+                                             width= 40,
+                                             mode=dv.DATAVIEW_CELL_EDITABLE)
+        self.dataviewCtrl.AppendTextColumn('value', 2, width = 100)
+        self.dataviewCtrl.AppendTextColumn('shape', 3)        
+        
+        #self.btn_load = wx.Button(self, label = 'Load')
+        self.btn_export = wx.Button(self, label = 'Export...')
+
+        
+        sizer.Add(self.filepicker, 0, wx.EXPAND|wx.ALL, 1)        
+        sizer.Add(self.dataviewCtrl, 1, wx.EXPAND|wx.ALL, 5)
+        sizer.Add(sizer_h, 0, wx.EXPAND|wx.ALL|wx.ALIGN_RIGHT, 5)        
+
+
+        #sizer_h.Add(self.btn_load, 0,   wx.EXPAND|wx.ALL, 1)
+        sizer_h.AddStretchSpacer(prop = 1)
+        sizer_h.Add(self.btn_export, 0, wx.EXPAND|wx.ALL, 1)
+
+
+        self.Layout()
+        self.Show()
+
+
+        self.export_flag = {}
+        model = HDFDataModel(export_flag = self.export_flag,
+                             dataset = self.dataset)
+        self.dataviewCtrl.AssociateModel(model)
+        model.DecRef()
+
+        self.Bind(wx.EVT_BUTTON, self.onExport, self.btn_export)
+        
+    def onExport(self, evt):
+        import ifigure.widgets.dialog as dialog        
+        flags = self.export_flag
+        path  = self.filepicker.GetPath()
+
+        try:
+            hdf_data_export(data =self.dataset,
+                        export_flag = flags,
+                        filename = path,
+                        verbose = True)
+        except:   
+            dialog.showtraceback(parent = self,
+                               txt='Failed to export HDF', 
+                               title='Error during HDF export',
+                               traceback=traceback.format_exc())
+        
+        self.Close()
+        evt.Skip()


### PR DESCRIPTION
Main change is to add HDF export window and adjust menu structure of
figure window.
HDF export window allows to save figure data/property to file.
This is not meant to replace “save figure”. Instead, it is simply a HDF
generator from which non piScope user can access figure data.