### PR TITLE
fixed the paste action in varviwer2

### DIFF
--- a/python/ifigure/widgets/var_viewerg2.py
+++ b/python/ifigure/widgets/var_viewerg2.py
@@ -659,7 +659,7 @@ class VarViewerG(wx.Panel):
                    dlg.Destroy()
                    if ret  != wx.ID_OK: continue
                self.GetTopLevelParent().set_status_text('Paste tree variable', timeout = 3000)
-               obj.setvar(key, data)
+               obj.setvar(key, data[key])
                obj._var_changed = True
             self.update()
         elif mode == 'trash':


### PR DESCRIPTION
* paste button in VarViewer is fixed to behave in the same way as the paste button in Shell Variable Viewer