### PR TITLE
this set the axes object when axes panel is opened

### DIFF
--- a/python/ifigure/widgets/artist_widgets.py
+++ b/python/ifigure/widgets/artist_widgets.py
@@ -1490,7 +1490,15 @@ class panel2(artist_widgets):
                     self.mode].get_selected_page_text()
 
             self.update_panel()
-
+            
+    def set_axes(self, ax):
+        if ax is None:
+            self.ax = None
+            self.enable(False)
+        else:
+            self.ax = weakref.ref(ax)
+            self.enable(True)
+        
     def onEL_Changed(self, evt):
         actions, name = evt.artist_panel.set_artist_property(evt)
         if actions is None:

--- a/python/ifigure/widgets/property_editor.py
+++ b/python/ifigure/widgets/property_editor.py
@@ -183,6 +183,12 @@ class property_editor(wx.Panel):
         else:
             self.b2.SetValue(True)
         self.CP2.GetSizer().Layout()
+
+        # set selected axes to panel 
+        canvas = self.get_canvas()
+        ax = canvas.axes_selection()
+        self.CP2.set_axes(ax)
+ 
         self.CP2.update_panel()
         self.OnPaneChanged()
         self.CP2.Layout()


### PR DESCRIPTION
This small fix updates the axes panel link to the selected axes, when axes panel is opened. 
