### PR TITLE
added hgapi fix

### DIFF
--- a/python/ifigure/mto/hg_support.py
+++ b/python/ifigure/mto/hg_support.py
@@ -27,6 +27,8 @@ import traceback
 import time
 import subprocess
 import shlex
+
+
 from fnmatch import fnmatch
 import ifigure.widgets.dialog as dialog
 from ifigure.mto.treedict import TreeDict
@@ -45,9 +47,13 @@ diffwindow = None
 usr = get_username()
 
 try:
+    org_lang = os.environ['LANG']
     import hgapi
-    has_hg = True
+    hgapi.Repo._env = os.environ.copy()
+    os.environ['LANG'] = org_lang
 
+    has_hg = True
+    
     def has_repo(obj):
         if not isinstance(obj, HGSupport):
             return False


### PR DESCRIPTION
This pull address the issue of getting

Fatal Python error: config_get_locale_encoding: failed to get the locale encoding: nl_langinfo(CODESET) failed

from any subprocess call which try to run Python. This failure is due to the change in locale
made in hgapi. It has been addressed in the following pull request, but until it will be 
release, we use this adjustment.

https://bitbucket.org/haard/hgapi/pull-requests/24/copy-osenviron-so-the-real-one-isnt


