### PR TITLE
Some minor updates, mainly, for windows; tested in Windows 10 under A…

### DIFF
--- a/python/ifigure/ifigure_app.py
+++ b/python/ifigure/ifigure_app.py
@@ -202,6 +202,7 @@ class ifigure_app(BookViewerFrame):
         self.BindTreeDictEvents()
         self.BindPVCVEvents()
 #       self.Bind(ifigure.events.TD_EVT_NEWHISTORY, self.onNewHistory)
+        self.Bind(wx.EVT_CLOSE, lambda evt: wx.GetApp().ExitMainLoop())
 
         self.shell.set_proj(self.proj)
 

--- a/python/ifigure/widgets/dialog.py
+++ b/python/ifigure/widgets/dialog.py
@@ -34,7 +34,8 @@ def read(parent=None,
     if open_dlg.ShowModal() == wx.ID_OK:
         path = open_dlg.GetPath()
         open_dlg.Destroy()
-    open_dlg.Destroy()
+    else:
+        open_dlg.Destroy()
     return path
 
 
@@ -49,7 +50,8 @@ def readdir(parent=None, message='Select directory to read', wildcard='*', defau
     if open_dlg.ShowModal() == wx.ID_OK:
         path = open_dlg.GetPath()
         open_dlg.Destroy()
-    open_dlg.Destroy()
+    else:    
+        open_dlg.Destroy()
     return path
 
 
@@ -76,7 +78,8 @@ def write(parent=None, defaultfile='',
         path = open_dlg.GetPath()
         wc = open_dlg.GetFilterIndex()
         open_dlg.Destroy()
-    open_dlg.Destroy()
+    else:
+        open_dlg.Destroy()
     if return_filterindex:
         return path, wc
     else:


### PR DESCRIPTION
Some minor troubles are corrected, mainly, for Windows OS:
1. Duplicated Distroy() calls in some dialogs made trouble in windows; linux is fine as I checked.
2. Killing process, which is followed by the routine to delete old temporary files, failed, loosing the proper error code.
3. MainLoop() of wx.App was not exiting, when the main window was closed; in linux, it was the same (Anaconda 3 with wxpython 4.0.4

The symptom was something like below..
```
D:\Users\spinhalf\Documents\piScope.new\python>python piscope.py
WARNING:root:Access is denied to get pid info.9816
reading extra color maps
numpy does not know type = complex256
DEBUG(BackendWXAggGL)::loading glcanvas12
Traceback (most recent call last):
  File "D:\Users\spinhalf\Documents\piScope.new\python\ifigure\ifigure_app.py", line 686, in onOpen
    defaultdir=os.getcwd())
  File "D:\Users\spinhalf\Documents\piScope.new\python\ifigure\widgets\dialog.py", line 37, in read
    open_dlg.Destroy()
RuntimeError: wrapped C/C++ object of type FileDialog has been deleted
DEBUG(iFigureApp)::ending program...(window close)
('editor detached', False)
forrtl: error (200): program aborting due to control-C event
Image              PC                Routine            Line        Source
libifcoremd.dll    00007FFB8DB33B58  Unknown               Unknown  Unknown
KERNELBASE.dll     00007FFBC52F4553  Unknown               Unknown  Unknown
KERNEL32.DLL       00007FFBC6BA7974  Unknown               Unknown  Unknown
ntdll.dll          00007FFBC8F0A2D1  Unknown               Unknown  Unknown
```

Now..

```
D:\Users\spinhalf\Documents\piScope.new\python>python piscope.py
('removing past crush dir', 'C:\\Users\\spinhalf\\AppData\\Local\\Temp\\piscope_spinhalf\\00Microwave.pid10156')
reading extra color maps
numpy does not know type = complex256
DEBUG(BackendWXAggGL)::loading glcanvas12
checking file contents...
done....(load)
initializing model...
done....(init) ProjectTop(proj)
DEBUG(BookViewer)::_force_layout
DEBUG(iFigureApp)::checking HG repo for updates
DEBUG(BookViewer)::_force_layout
main loop finished
following is for debug to check if normal exit
<_MainThread(MainThread, started 5896)>
WindowList: [ifigure_app(book=None), <wx._core.Frame object at 0x00000219D2538E58>, <wx._core.Frame object at 0x00000219C0571D38>, <ifigure.widgets.logwindow.Logwindow object at 0x00000219D253FF78>, <wx._core.Frame object at 0x00000219C0571AF8>, <ifigure.widgets.tipwindow.Tipwindow object at 0x00000219D48B1948>, <wx._core.Frame object at 0x00000219C0571CA8>]
```